### PR TITLE
Add sticky sessions

### DIFF
--- a/charts/chatbot/templates/service.yaml
+++ b/charts/chatbot/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "chatbot.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
-  {{- if and .Values.service.sessionAffinity (ne .Values.service.sessionAffinity "None") }}
+  {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- if .Values.service.sessionAffinityConfig }}
   sessionAffinityConfig:

--- a/charts/chatbot/templates/service.yaml
+++ b/charts/chatbot/templates/service.yaml
@@ -6,7 +6,13 @@ metadata:
     {{- include "chatbot.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
-  sessionAffinity: ClientIP
+  {{- if and .Values.service.sessionAffinity (ne .Values.service.sessionAffinity "None") }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+{{ toYaml .Values.service.sessionAffinityConfig | indent 4 }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port | default 80 }}
       targetPort: http-web

--- a/charts/chatbot/templates/service.yaml
+++ b/charts/chatbot/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "chatbot.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type | default "ClusterIP" }}
+  sessionAffinity: ClientIP
   ports:
     - port: {{ .Values.service.port | default 80 }}
       targetPort: http-web

--- a/charts/chatbot/values.yaml
+++ b/charts/chatbot/values.yaml
@@ -57,6 +57,15 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  # sessionAffinity can be "ClientIP" or "None".
+  # "ClientIP" enables sticky sessions. "None" (default) disables it.
+  sessionAffinity: "None"
+  # sessionAffinityConfig holds the configuration for session affinity.
+  # Example for ClientIP:
+  # sessionAffinityConfig:
+  #   clientIP:
+  #     timeoutSeconds: 10800
+  sessionAffinityConfig: {}
 
 
 resources: {}

--- a/charts/chatbot/values.yaml
+++ b/charts/chatbot/values.yaml
@@ -64,11 +64,12 @@ service:
 
   # sessionAffinityConfig holds the configuration for session affinity
   # when sessionAffinity is set (e.g., to "ClientIP").
+  # This field is optional and should only be defined if needed.
   # Example for ClientIP:
   # sessionAffinityConfig:
   #   clientIP:
   #     timeoutSeconds: 10800
-  sessionAffinityConfig: {}
+  # sessionAffinityConfig: {} # Ensure this is effectively removed or commented
 
 
 resources: {}

--- a/charts/chatbot/values.yaml
+++ b/charts/chatbot/values.yaml
@@ -57,10 +57,13 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
-  # sessionAffinity can be "ClientIP" or "None".
-  # "ClientIP" enables sticky sessions. "None" (default) disables it.
-  sessionAffinity: "None"
-  # sessionAffinityConfig holds the configuration for session affinity.
+  # sessionAffinity specifies the session affinity strategy.
+  # If defined (e.g., "ClientIP"), sticky sessions are enabled.
+  # If not defined, session affinity is disabled.
+  # sessionAffinity: "ClientIP" # Example if you want to enable it
+
+  # sessionAffinityConfig holds the configuration for session affinity
+  # when sessionAffinity is set (e.g., to "ClientIP").
   # Example for ClientIP:
   # sessionAffinityConfig:
   #   clientIP:


### PR DESCRIPTION
Add sticky sessions as an optional for the chart. This will help with MCP stream connections.
Add a config for sessions if that is provided.