### PR TITLE
feat: add git tag and sha to docker image tags

### DIFF
--- a/.github/workflows/aiohttp-publish.yml
+++ b/.github/workflows/aiohttp-publish.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Get nearest Git tag
         id: git-tag
-        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> $GITHUB_OUTPUT
+        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> "$GITHUB_OUTPUT"
 
       - name: Get short SHA
         id: git-sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -85,6 +85,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
+            type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/aiohttp-publish.yml
+++ b/.github/workflows/aiohttp-publish.yml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get nearest Git tag
+        id: git-tag
+        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> $GITHUB_OUTPUT
+
+      - name: Get short SHA
+        id: git-sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -74,6 +84,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/aiohttp-publish.yml
+++ b/.github/workflows/aiohttp-publish.yml
@@ -40,13 +40,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get nearest Git tag
-        id: git-tag
-        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> "$GITHUB_OUTPUT"
-
-      - name: Get short SHA
-        id: git-sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Generate custom Docker tag
+        id: generate_custom_tag
+        run: |
+          tag=$(git describe --tags --abbrev=0 || echo '0.0.0')
+          echo "Raw tag: ${tag}"
+          sha=$(git rev-parse --short HEAD)
+          echo "Raw sha: ${sha}"
+          custom_tag_value="${tag}-${sha}"
+          echo "Custom tag value: ${custom_tag_value}"
+          echo "value=${custom_tag_value}" >> "$GITHUB_OUTPUT"
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -84,7 +87,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
+            type=raw,value={{steps.generate_custom_tag.outputs.value}}
             type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.github/workflows/chatbot-publish.yml
+++ b/.github/workflows/chatbot-publish.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Get nearest Git tag
         id: git-tag
-        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> $GITHUB_OUTPUT
+        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> "$GITHUB_OUTPUT"
 
       - name: Get short SHA
         id: git-sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -85,6 +85,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
+            type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/chatbot-publish.yml
+++ b/.github/workflows/chatbot-publish.yml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get nearest Git tag
+        id: git-tag
+        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> $GITHUB_OUTPUT
+
+      - name: Get short SHA
+        id: git-sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -74,6 +84,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/chatbot-publish.yml
+++ b/.github/workflows/chatbot-publish.yml
@@ -40,13 +40,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get nearest Git tag
-        id: git-tag
-        run: echo "tag=$(git describe --tags --abbrev=0 || echo '0.0.0')" >> "$GITHUB_OUTPUT"
-
-      - name: Get short SHA
-        id: git-sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Generate custom Docker tag
+        id: generate_custom_tag
+        run: |
+          tag=$(git describe --tags --abbrev=0 || echo '0.0.0')
+          echo "Raw tag: ${tag}"
+          sha=$(git rev-parse --short HEAD)
+          echo "Raw sha: ${sha}"
+          custom_tag_value="${tag}-${sha}"
+          echo "Custom tag value: ${custom_tag_value}"
+          echo "value=${custom_tag_value}" >> "$GITHUB_OUTPUT"
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -84,7 +87,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value={{steps.git-tag.outputs.tag}}-{{steps.git-sha.outputs.sha}}
+            type=raw,value={{steps.generate_custom_tag.outputs.value}}
             type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)


### PR DESCRIPTION
This change updates the Docker publishing workflows to include a new tag format: nearest_git_tag-short_sha.

If no Git tags are found, it defaults to `0.0.0` for the tag part.