### PR TITLE
Refactor: Modernize type hints to use built-in types and collections.abc

### DIFF
--- a/aiohttp-container/customer/cli.py
+++ b/aiohttp-container/customer/cli.py
@@ -9,8 +9,6 @@ import logging
 import logging.config
 from pydantic_yaml import to_yaml_str
 
-from typing import List
-
 from .config import ServiceConfig
 
 

--- a/aiohttp-container/customer/config/__init__.py
+++ b/aiohttp-container/customer/config/__init__.py
@@ -6,7 +6,7 @@ from pydantic import HttpUrl
 from pydantic_settings import BaseSettings, YamlConfigSettingsSource, SettingsConfigDict
 from pydantic_file_secrets import FileSecretsSettingsSource
 from pathlib import Path
-from typing import Dict, Any, Self, List, Literal
+from typing import Any, Self, Literal # TODO: Review Self and Literal for Python version compatibility
 from datetime import timedelta
 
 
@@ -47,7 +47,7 @@ class MyAiConfig(BaseModel):
     Configuration for the MyAI bot
     """
 
-    system_instruction: List[AIPromptConfig] = Field(
+    system_instruction: list[AIPromptConfig] = Field(
         description="List of system instructions for the bot",
     )
 
@@ -61,7 +61,7 @@ class ServiceConfig(BaseSettings):
     Configuration for the service
     """
 
-    logging: Dict[str, Any] = Field(description="Logging configuration")
+    logging: dict[str, Any] = Field(description="Logging configuration")
     myai: MyAiConfig = Field(description="MyAI bot configuration")
 
     webservice: WebServerConfig = Field(description="Web server configuration")

--- a/aiohttp-container/customer/config/tool.py
+++ b/aiohttp-container/customer/config/tool.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import List
 from pydantic import BaseModel, Field
 from pydantic import HttpUrl
 from enum import Enum
@@ -43,11 +42,11 @@ class ToolConfig(BaseModel):
 class ToolBoxConfig(BaseModel):
     """Configuration for tool execution."""
 
-    tools: List[ToolConfig] = Field(
+    tools: list[ToolConfig] = Field(
         description="Per-tool configuration with default settings"
     )
     max_concurrent: int = Field(
         description="Default maximum number of concurrent instances for tools"
     )
 
-    mcps: List[McpConfig] = Field(description="MCP configuration")
+    mcps: list[McpConfig] = Field(description="MCP configuration")

--- a/aiohttp-container/customer/hams/config.py
+++ b/aiohttp-container/customer/hams/config.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import timedelta
 import aiohttp
 import logging
-from typing import List, Union
 from pydantic import Field, BaseModel
 from pydantic import HttpUrl
 from abc import ABC, abstractmethod
@@ -67,7 +66,7 @@ class HttpCheck(HamsCheck):
                     return response.status == self.returncode
 
 
-CheckType = Union[HttpCheck]
+CheckType = HttpCheck # Replaced Union[HttpCheck] with HttpCheck as it's the only type
 
 
 class HamsChecks(BaseModel):
@@ -81,10 +80,10 @@ class HamsChecks(BaseModel):
     fails: int = Field(
         description="Number of fails before the check is considered failed"
     )
-    preflights: List[CheckType] = Field(description="Preflight checks")
-    shutdowns: List[CheckType] = Field(description="Shutdown checks")
+    preflights: list[CheckType] = Field(description="Preflight checks")
+    shutdowns: list[CheckType] = Field(description="Shutdown checks")
 
-    async def run_checks(self, checks: List[CheckType]) -> bool:
+    async def run_checks(self, checks: list[CheckType]) -> bool:
         """
         Run the checks with timeouts and fail counting
         Will reply True if all checks pass

--- a/chatbot-container/chatbot/cli.py
+++ b/chatbot-container/chatbot/cli.py
@@ -9,8 +9,6 @@ import logging
 import logging.config
 from pydantic_yaml import to_yaml_str
 
-from typing import List
-
 from .config import ServiceConfig
 
 

--- a/chatbot-container/chatbot/config/__init__.py
+++ b/chatbot-container/chatbot/config/__init__.py
@@ -4,7 +4,7 @@ from pydantic import Field, BaseModel, SecretStr, field_validator, HttpUrl
 from pydantic_settings import BaseSettings, YamlConfigSettingsSource
 from pydantic_file_secrets import FileSecretsSettingsSource
 from pathlib import Path
-from typing import Dict, Any, Self, List, Literal
+from typing import Any, Self, Literal # TODO: Review Self and Literal for Python version compatibility
 from datetime import timedelta
 
 
@@ -64,7 +64,7 @@ class MyAiConfig(BaseModel):
     Configuration for the MyAI bot
     """
 
-    system_instruction: List[AIPromptConfig] = Field(
+    system_instruction: list[AIPromptConfig] = Field(
         description="List of system instructions for the bot",
     )
 
@@ -130,7 +130,7 @@ class LangchainConfig(BaseModel):
     context_length: int = Field(
         default=4096, description="Maximum context length for the model"
     )
-    stop_sequences: List[str] = Field(
+    stop_sequences: list[str] = Field(
         default_factory=list, description="List of sequences that will stop generation"
     )
     timeout: int = Field(
@@ -167,7 +167,7 @@ class ServiceConfig(BaseSettings):
     Configuration for the service
     """
 
-    logging: Dict[str, Any] = Field(description="Logging configuration")
+    logging: dict[str, Any] = Field(description="Logging configuration")
     bot: BotConfig = Field(description="Bot configuration")
     aiclient: LangchainConfig = Field(description="AI Client configuration")
     myai: MyAiConfig = Field(description="MyAI bot configuration")

--- a/chatbot-container/chatbot/config/tool.py
+++ b/chatbot-container/chatbot/config/tool.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import List
 from pydantic import BaseModel, Field
 from pydantic import HttpUrl
 from enum import Enum
@@ -45,11 +44,11 @@ class ToolConfig(BaseModel):
 class ToolBoxConfig(BaseModel):
     """Configuration for tool execution."""
 
-    tools: List[ToolConfig] = Field(
+    tools: list[ToolConfig] = Field(
         description="Per-tool configuration with default settings"
     )
     max_concurrent: int = Field(
         description="Default maximum number of concurrent instances for tools"
     )
 
-    mcps: List[McpConfig] = Field(description="MCP configuration")
+    mcps: list[McpConfig] = Field(description="MCP configuration")

--- a/chatbot-container/chatbot/hams/config.py
+++ b/chatbot-container/chatbot/hams/config.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import timedelta
 import aiohttp
 import logging
-from typing import List, Union
 from pydantic import Field, BaseModel
 from pydantic import HttpUrl
 from abc import ABC, abstractmethod
@@ -67,7 +66,7 @@ class HttpCheck(HamsCheck):
                     return response.status == self.returncode
 
 
-CheckType = Union[HttpCheck]
+CheckType = HttpCheck # Replaced Union[HttpCheck] with HttpCheck as it's the only type
 
 
 class HamsChecks(BaseModel):
@@ -81,10 +80,10 @@ class HamsChecks(BaseModel):
     fails: int = Field(
         description="Number of fails before the check is considered failed"
     )
-    preflights: List[CheckType] = Field(description="Preflight checks")
-    shutdowns: List[CheckType] = Field(description="Shutdown checks")
+    preflights: list[CheckType] = Field(description="Preflight checks")
+    shutdowns: list[CheckType] = Field(description="Shutdown checks")
 
-    async def run_checks(self, checks: List[CheckType]) -> bool:
+    async def run_checks(self, checks: list[CheckType]) -> bool:
         """
         Run the checks with timeouts and fail counting
         Will reply True if all checks pass

--- a/chatbot-container/chatbot/llmconversationhandler/__init__.py
+++ b/chatbot-container/chatbot/llmconversationhandler/__init__.py
@@ -1,5 +1,6 @@
 import base64
-from typing import Any, Callable, Dict, List
+from typing import Any
+from collections.abc import Sequence, Callable # For List and Callable
 from chatbot.config import MyAiConfig, ServiceConfig
 from aiohttp import web
 from chatbot import keys
@@ -264,7 +265,7 @@ class LLMConversationHandler:
         return self.graph
 
 
-    def register_tools(self, tools: List[StructuredTool]):
+    def register_tools(self, tools: Sequence[StructuredTool]):
         """Registers the tools with the client."""
         self.function_registry.register_tools(tools)
 

--- a/chatbot-container/chatbot/llmconversationhandler/graph_state.py
+++ b/chatbot-container/chatbot/llmconversationhandler/graph_state.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, TypedDict
+from typing import Annotated, TypedDict # TODO: Review Annotated and TypedDict for Python version compatibility
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
 
@@ -9,4 +9,4 @@ class AgentState(TypedDict):
     Attributes:
         messages: The list of messages that have been exchanged in the conversation.
     """
-    messages: Annotated[List[BaseMessage], add_messages]
+    messages: Annotated[list[BaseMessage], add_messages]

--- a/chatbot-container/chatbot/llmconversationhandler/toolregistry.py
+++ b/chatbot-container/chatbot/llmconversationhandler/toolregistry.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import List, Dict, Callable, Any
+from typing import Any
+from collections.abc import Sequence, Callable # For List and Callable
 from chatbot.config.tool import ToolBoxConfig
 from langchain_core.messages.tool import ToolCall, ToolMessage
 from langchain_core.tools.structured import StructuredTool
@@ -28,7 +29,7 @@ class ToolDefinition:
 
 class ToolRegistry:
     def __init__(self, toolboxConfig: ToolBoxConfig):
-        self.registry: Dict[str, ToolDefinition] = {}
+        self.registry: dict[str, ToolDefinition] = {}
 
         self.toolboxConfig = toolboxConfig
 
@@ -42,12 +43,12 @@ class ToolRegistry:
             ["tool_name"],
         )
 
-    def all_tools(self) -> List[StructuredTool]:
+    def all_tools(self) -> Sequence[StructuredTool]:
         print(f"ToolRegistry.all_tools: {self.registry}")
 
         return [mytool.tool for mytool in self.registry.values()]
 
-    def register_tools(self, tools: List[StructuredTool]) -> None:
+    def register_tools(self, tools: Sequence[StructuredTool]) -> None:
         """Registers the tools with the Gemini client."""
 
         for tool in tools:
@@ -81,7 +82,7 @@ class ToolRegistry:
 
         logger.debug(f"Tool registered: {tool_name}")
 
-    async def perform_tool_actions(self, parts: List[ToolCall]) -> List[ToolMessage]:
+    async def perform_tool_actions(self, parts: Sequence[ToolCall]) -> Sequence[ToolMessage]:
         """Performs actions using the registered tools.
         Reply back with an array to match what was called
         """

--- a/chatbot-container/chatbot/tools/customer.py
+++ b/chatbot-container/chatbot/tools/customer.py
@@ -1,7 +1,7 @@
-from typing import Annotated
 import requests
 import logging
 from langchain_core.tools import InjectedToolArg, tool
+# from typing import Annotated # Annotated is not used
 from langchain_core.runnables import RunnableConfig
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Updated old-style type hints (e.g., `typing.List`, `typing.Dict`) to their modern equivalents (e.g., `list`, `dict`, `collections.abc.Sequence`, `collections.abc.Callable`).

Removed unnecessary imports from the `typing` module where built-in types suffice. Noted potential Python version compatibility considerations for types like `Self`, `Literal`, `Annotated`, and `TypedDict` if the project targets older Python runtimes.